### PR TITLE
Log discarded empty outbox payloads as warnings

### DIFF
--- a/src/WinFIMLog/Jobs/EventOutboxPublisher.cs
+++ b/src/WinFIMLog/Jobs/EventOutboxPublisher.cs
@@ -32,7 +32,7 @@ namespace WinFIMLog.Jobs
                 if (string.IsNullOrWhiteSpace(item.Payload))
                 {
                     outbox.DiscardInvalid(item, "EmptyPayload");
-                    logger.LogError(
+                    logger.LogWarning(
                         "Event outbox record {RecordId} has an empty payload and was discarded",
                         item.Id);
                     continue;

--- a/tests/WinFIMLog.Tests/EventOutboxTests.cs
+++ b/tests/WinFIMLog.Tests/EventOutboxTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using LiteDB;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -105,8 +106,8 @@ public sealed class EventOutboxTests
             CreatedAt = DateTimeOffset.UtcNow,
             NextAttemptAt = DateTimeOffset.MinValue
         });
-        var publisher = new EventOutboxPublisher(outbox, new FailOnceWriter(),
-            NullLogger<EventOutboxPublisher>.Instance);
+        var logger = new RecordingLogger<EventOutboxPublisher>();
+        var publisher = new EventOutboxPublisher(outbox, new FailOnceWriter(), logger);
 
         Assert.IsTrue(publisher.PublishReady());
 
@@ -114,6 +115,7 @@ public sealed class EventOutboxTests
         Assert.IsNotNull(discarded.DeliveredAt);
         Assert.AreEqual(1, discarded.DeliveryAttempts);
         Assert.AreEqual("EmptyPayload", discarded.LastError);
+        Assert.AreSequenceEqual([LogLevel.Warning], logger.Levels);
         Assert.IsFalse(publisher.PublishReady());
     }
 
@@ -155,5 +157,17 @@ public sealed class EventOutboxTests
             _ = record.ToJson();
             if (fail) { fail = false; throw new IOException("fault injection"); }
         }
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogLevel> Levels { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => Levels.Add(logLevel);
     }
 }


### PR DESCRIPTION
### Motivation
- Empty event outbox payloads are discarded but were logged as errors; this should be a warning-level event since discarded empty payloads are an expected non-fatal condition.

### Description
- Change `logger.LogError` to `logger.LogWarning` for empty outbox payload discard in `src/WinFIMLog/Jobs/EventOutboxPublisher.cs` and add a test harness (`RecordingLogger<T>`) plus an assertion in `tests/WinFIMLog.Tests/EventOutboxTests.cs` to verify a `LogLevel.Warning` is emitted.

### Testing
- Ran the test suite with `dotnet test WinFIMLog.slnx --configuration Release` and all tests passed (98 passed, 5 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82a9ee3df483328bc8fd3daf3771db)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Empty event outbox payloads are now logged as warnings instead of errors. This aligns with expected non-fatal discards and reduces noisy error alerts; delivery behavior is unchanged.

**Review notes**
- Replace `logger.LogError` with `logger.LogWarning` when discarding `EmptyPayload` in `src/WinFIMLog/Jobs/EventOutboxPublisher.cs`.
- Add a `RecordingLogger<T>` in `tests/WinFIMLog.Tests/EventOutboxTests.cs` and assert `LogLevel.Warning` is emitted.
- Update alerting or dashboards if they previously depended on this message being logged at error level.

<sup>Written for commit 965f00c3f669198e442f2fe4b2e9ac59ec51bde6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zbalkan/WinFIMLog/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

